### PR TITLE
New tx

### DIFF
--- a/Camino.postman_collection.json
+++ b/Camino.postman_collection.json
@@ -1,4846 +1,3790 @@
 {
-	"info": {
-		"_postman_id": "89c2c02e-22ee-4188-a8bf-659ff88a358a",
-		"name": "Camino",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "16493174"
-	},
-	"item": [
-		{
-			"name": "Admin",
-			"item": [
-				{
-					"name": "alias",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.alias\",\n    \"params\": {\n        \"alias\":\"myAlias\",\n        \"endpoint\":\"bc/X\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/build/apis/admin-api#admin-alias)"
-					},
-					"response": []
-				},
-				{
-					"name": "getNodeSigner",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getNodeSigner\",\n    \"params\": {\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/build/apis/admin-api#admin-alias)"
-					},
-					"response": []
-				},
-				{
-					"name": "aliasChain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.aliasChain\",\n    \"params\": {\n        \"chain\":\"{{avalanceBlockchainId}}\",\n        \"alias\":\"myBlockchainAlias\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used. [More info](https://docs.avax.network/build/apis/admin-api#admin-aliaschain)"
-					},
-					"response": []
-				},
-				{
-					"name": "getChainAliases",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getChainAliases\",\n    \"params\" :{\n        \"chain\":\"2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-lockprofile)"
-					},
-					"response": []
-				},
-				{
-					"name": "getLoggerLevel",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getLoggerLevel\",\n    \"params\" :{\n        \"loggerName\":\"C\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Returns log and display levels of loggers. [More info](https://docs.avax.network/build/avalanchego-apis/admin#admingetloggerlevel)"
-					},
-					"response": []
-				},
-				{
-					"name": "loadVMs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.loadVMs\",\n    \"params\" :{}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Dynamically loads any virtual machines installed on the node as plugins. [More info](https://docs.avax.network/build/avalanchego-apis/admin#adminloadvms)"
-					},
-					"response": []
-				},
-				{
-					"name": "lockProfile",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.lockProfile\",\n    \"params\" :{}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-lockprofile)"
-					},
-					"response": []
-				},
-				{
-					"name": "memoryProfile",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.memoryProfile\",\n    \"params\" :{}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-memoryprofile)"
-					},
-					"response": []
-				},
-				{
-					"name": "setLoggerLevel",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.setLoggerLevel\",\n    \"params\" :{\n        \"loggerName\": \"C\",\n        \"logLevel\": \"DEBUG\",\n        \"displayLevel\": \"INFO\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Sets log and display levels of loggers. [More info](https://docs.avax.network/build/avalanchego-apis/admin#adminsetloggerlevel)"
-					},
-					"response": []
-				},
-				{
-					"name": "startCPUProfiler",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.startCPUProfiler\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Start profiling the CPU utilization of the node. Will write the profile to the specified file on stop. [More info](https://docs.avax.network/build/apis/admin-api#admin-startcpuprofiler)"
-					},
-					"response": []
-				},
-				{
-					"name": "stopCPUProfiler",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.stopCPUProfiler\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/admin",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"admin"
-							]
-						},
-						"description": "Stop the CPU profile that was previously started. [More info](https://docs.avax.network/build/apis/admin-api#admin-stopcpuprofiler)"
-					},
-					"response": []
-				}
-			],
-			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)"
-		},
-		{
-			"name": "Auth",
-			"item": [
-				{
-					"name": "newToken",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.newToken\",\n    \"params\": {\n        \"password\":\"{{authPassword}}\",\n        \"endpoints\":[\"/ext/bc/X\", \"/ext/info\"]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/auth",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"auth"
-							]
-						},
-						"description": "Creates a new authorization token that grants access to one or more API endpoints.\n [More info](https://docs.avax.network/build/apis/auth-api#auth-newtoken)"
-					},
-					"response": []
-				},
-				{
-					"name": "revokeToken",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.revokeToken\",\n    \"params\": {\n        \"password\":\"password goes here\",\n        \"token\":\"token goes here\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/auth",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"auth"
-							]
-						},
-						"description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.\nIf the token is invalid, does nothing. [More info](https://docs.avax.network/build/apis/auth-api#auth-revoketoken)"
-					},
-					"response": []
-				},
-				{
-					"name": "changePassword",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.changePassword\",\n    \"params\": {\n        \"oldPassword\":\"old password goes here\",\n        \"newPassword\":\"new password goes here\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/auth",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"auth"
-							]
-						},
-						"description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.avax.network/build/apis/auth-api#auth-changepassword)"
-					},
-					"response": []
-				}
-			],
-			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)"
-		},
-		{
-			"name": "AVM",
-			"item": [
-				{
-					"name": "buildGenesis",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 1337,\n        \"encoding\":\"cb58\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/vm/avm",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"vm",
-								"avm"
-							]
-						},
-						"description": "Given a JSON representation of this Virtual Machine’s genesis state, create the byte representation of that state. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmbuildgenesis)"
-					},
-					"response": []
-				},
-				{
-					"name": "createAddress",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.createAddress\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createaddress)"
-					},
-					"response": []
-				},
-				{
-					"name": "createAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createFixedCapAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"denomination\": 0,  \n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createfixedcapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createNFTAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createnftasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createVariableCapAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "export",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000         ,\n        \"assetID\": \"AVAX\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexport)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"C\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "getAddressTxs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Returns all transactions that change the balance of the given address. A transaction is said to change an address's balance if either is true:\n\n*   A UTXO that the transaction consumes was at least partially owned by the address.\n*   A UTXO that the transaction produces is at least partially owned by the address.\n    \n\nNote: Indexing (`index-transactions`) must be enabled in the X-chain config. [More info](https://docs.avax.network/build/avalanchego-apis/x-chain#avm-get-address-txs-api)"
-					},
-					"response": []
-				},
-				{
-					"name": "getAllBalances",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the balances of all assets controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getallbalances)"
-					},
-					"response": []
-				},
-				{
-					"name": "getAssetDescription",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getAssetDescription\",\n    \"params\" :{\n        \"assetID\" :\"{{avaxAssetId}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get information about an asset. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getassetdescription)"
-					},
-					"response": []
-				},
-				{
-					"name": "getBalance",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var template = `",
-									"    <table bgcolor=\"#FFFFFF\">",
-									"        <tr>",
-									"            <th>Name</th>",
-									"            <th>Email</th>",
-									"        </tr>",
-									"",
-									"        {{#each response}}",
-									"            <tr>",
-									"                <td>{{name}}</td>",
-									"                <td>{{email}}</td>",
-									"            </tr>",
-									"        {{/each}}",
-									"    </table>",
-									"`;",
-									"",
-									"// Set visualizer",
-									"pm.visualizer.set(template, {",
-									"    // Pass the response body parsed as JSON as `data`",
-									"    response: pm.response.json()",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"avm.getBalance\",\n  \"params\" :{\n      \"address\":\"{{xchainAddress}}\",\n      \"assetID\": \"{{avaxAssetId}}\"\n  }\n} ",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTx\",\n    \"params\" :{\n        \"txID\":\"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettx)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTxStatus",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"2HHr7xUJgWiLESV7g8T3oWfWvdpWJXd4Hctj6U3KhzUN6EsgBG\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettxstatus)"
-					},
-					"response": []
-				},
-				{
-					"name": "getUTXOs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getutxos)"
-					},
-					"response": []
-				},
-				{
-					"name": "import",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.import\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "importAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"C\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "issueTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.issueTx\",\n    \"params\" :{\n        \"tx\":\"6sTENqXfk3gahxkJbEPsmX9eJTEFZRSRw83cRJqoHWBiaeAhVbz9QV4i6SLd6Dek4eLsojeR8FbT3arFtsGz9ycpHFaWHLX69edJPEmj2tPApsEqsFd7wDVp7fFxkG6HmySR\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "listAddresses",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.listAddresses\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-listaddresses)"
-					},
-					"response": []
-				},
-				{
-					"name": "mint",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mint)"
-					},
-					"response": []
-				},
-				{
-					"name": "mintNFT",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" ,\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mintnft)"
-					},
-					"response": []
-				},
-				{
-					"name": "send",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
-					},
-					"response": []
-				},
-				{
-					"name": "sendAsManager",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendAsManager\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"feeFrom\": [\"{{xchainAddress}}\"],\n        \"feeChangeAddr\": \"{{xchainAddress}}\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
-					},
-					"response": []
-				},
-				{
-					"name": "sendMultiple",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendMultiple\",\n    \"params\" :{ \n        \"outputs\": [\n            {\n                \"assetID\" : \"{{avaxAssetId}}\",\n                \"to\"      : \"{{xchainAddress}}\",\n                \"amount\"  : 1000000000\n            }\n        ],\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendmultiple)"
-					},
-					"response": []
-				},
-				{
-					"name": "sendNFT",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendnft)"
-					},
-					"response": []
-				},
-				{
-					"name": "updateManagedAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.updateManagedAsset\",\n    \"params\" :{ \n        \"assetID\" : {{avaxAssetId}},\n        \"frozen\": true,\n        \"manager\":{\n            \"threshold\": 1,\n            \"addresses\": [\n                \"{{xchainAddress}}\"\n            ]\n        },\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
-					},
-					"response": []
-				}
-			],
-			"description": "The X-Chain, Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.avax.network/v1.0/en/api/avm)"
-		},
-		{
-			"name": "EVM",
-			"item": [
-				{
-					"name": "eth_baseFee",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_baseFee\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Get the base fee for the next block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_baseFee)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_blockNumber",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_blockNumber\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting the most recent block number. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-the-most-recent-block-number)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_call",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_call\",\n    \"params\": [\n        {\n            \"to\": \"0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7\",\n            \"data\": \"0xc92aecc4\"\n        },\n        \"latest\"\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Call a contract. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#call-a-contract)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_chainId",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_chainId\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Not well documented in JSON-RPC references. See instead EIP694. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-the-chain-id)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getAssetBalance",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getAssetBalance\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\",\n        \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting an account’s non-AVAX balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-non-avax-balance)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getBalance",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting an account’s balance. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-an-accounts-balance)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_maxPriorityFeePerGas",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_maxPriorityFeePerGas\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Get the priority fee needed to be included in a block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_maxPriorityFeePerGas)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_signTransaction",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_signTransaction\",\n    \"params\": [{\n        \"from\": \"0xa64b27635c967dfe9674926bc004626163ddce97\",\n        \"to\": \"0x1c5b0e12e90e9c52235babad76cfccab2519bb95\",\n        \"gas\": \"0x5208\",\n        \"gasPrice\": \"0x0\",\n        \"nonce\": \"0x0\",\n        \"value\": \"0x0\"\n    }],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#signing-a-transaction)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getTransactionCount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting an account’s nonce. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-an-accounts-nonce)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_sendRawTransaction",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_sendRawTransaction\",\n    \"params\": [\n        \"0xf8628080825208941c5b0e12e90e9c52235babad76cfccab2519bb958080830150efa0308ca8002f3df1a468eea9973d2d618eb866e2ef0a57cba4d34efb3025b70a0aa0592b7b0a803e7b70ec26dd74ab85aa71126198eff5552e5be638e6e26a455ee0\"\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#send-a-raw-transaction)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getBlockByHash",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBlockByHash\",\n    \"params\": [\n        \"0x14d9c2aeec20254d966a947e23eb3172ae5067e66fd4e69aecc3c9d6ff24443a\",\n        true\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting a block by hash. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-a-block-by-hash)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getBlockByNumber",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBlockByNumber\",\n    \"params\": [\n        \"0x5\",\n        true\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting a block by number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-block-by-number)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getTransactionByHash",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionByHash\",\n    \"params\": [\n        \"0xd33150a3f3783f29084eee4e12098f3ef707557f8deb916677a9af68e05613b7\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting a transaction by hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-by-hash)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_getTransactionReceipt",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionReceipt\",\n    \"params\": [\n        \"0xd33150a3f3783f29084eee4e12098f3ef707557f8deb916677a9af68e05613b7\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting a transaction receipt. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-receipt)"
-					},
-					"response": []
-				},
-				{
-					"name": "export",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"method\" :\"avax.export\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 25,\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"assetID\": \"FSznYPiqrJ3WtGurw54re47oDpGXQ8THc8yZ4fEDX4G8cGqbn\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"method\" :\"avax.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 999000000,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"method\" :\"avax.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{cchainAddress}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportkey)\n\n"
-					},
-					"response": []
-				},
-				{
-					"name": "getAtomicTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
-					},
-					"response": []
-				},
-				{
-					"name": "getAtomicTxStatus",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getAtomicTxStatus\",\n    \"params\": {\n        \"txID\": \"n1D9UkjiryEBtW8qznD1TDkGEuYRFj5tLaS8NhVpMLYsx1FHa\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgettxstatus)"
-					},
-					"response": []
-				},
-				{
-					"name": "getUTXOs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{cchainbech32address}}\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
-					},
-					"response": []
-				},
-				{
-					"name": "import",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"method\": \"avax.import\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "importAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Import AVAX from the X-Chain to an account on the C-Chain.\nBefore calling this method, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/evm/#evmimportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "issueTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avax.issueTx\",\n    \"params\" :{\n        \"tx\":\"0x00\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/avax",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						},
-						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
-					},
-					"response": []
-				},
-				{
-					"name": "net_version",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_version\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting the network ID. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-network-id)"
-					},
-					"response": []
-				},
-				{
-					"name": "personal_newAccount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_newAccount\",\n    \"params\": [\n        \"cheese\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Creating a new account (private key generated automatically)\n\nThe EVM will create a new account using the passphrase `cheese` to encrypt and store the new account credentials. cheese is not the seed phrase and cannot be used to restore this account from scratch. Calling this function repeatedly with the same passphrase will create multiple unique accounts. Also keep in mind there are no options to export private keys stored in the EVM database. Users are encouraged to use wallet software instead for safer account creation and backup. This method is more suitable for quick account creation for a testnet."
-					},
-					"response": []
-				},
-				{
-					"name": "personal_importRawKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_importRawKey\",\n    \"params\": [\n        \"627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d07\",\n        \"{{cchainPassphrase}}\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Creating a new account (using plaintext private key).\n\nIf the private key is known upfront, it can be provided as plaintext to load into the EVM account database. For more secure account management, consider using wallet software instead. The example below loads the private key `0x627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d06` with the passphrase `this is my passphrase`. Note that `0x` prefix cannot be included in the private key argument, otherwise the EVM will throw an error. The example response returns the associated public key."
-					},
-					"response": []
-				},
-				{
-					"name": "personal_listAccounts",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_listAccounts\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Listing accounts loaded in EVM node. [More info](https://docs.avax.network/v1.0/en/api/evm/#listing-accounts-loaded-in-evm-node)"
-					},
-					"response": []
-				},
-				{
-					"name": "personal_unlockAccount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_unlockAccount\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"{{cchainPassphrase}}\",\n        600\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.avax.network/v1.0/en/api/evm/#unlocking-an-account)"
-					},
-					"response": []
-				},
-				{
-					"name": "txpool_status",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"txpool_status\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-count-of-pending-transactions)"
-					},
-					"response": []
-				},
-				{
-					"name": "web3_clientVersion",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_clientVersion\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting the current client version. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-current-client-version)"
-					},
-					"response": []
-				},
-				{
-					"name": "web3_sha3",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_sha3\",\n    \"params\": [\n        \"0x736e6f7773746f726d\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/C/rpc",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
-					},
-					"response": []
-				}
-			],
-			"description": "This document describes the API of the C-Chain, which is an instance of the Ethereum Virtual Machine (EVM.)\n\nNote: Ethereum has its own notion of `networkID` and `chainID`. The C-Chain uses `1` and `43110` for these values, obtained using the `net_version` and `eth_chainId` methods shown below. These have no relationship to AVA’s view of networkID and chainID, and are purely internal to the C-Chain. [More info](https://docs.avax.network/v1.0/en/api/evm)"
-		},
-		{
-			"name": "Health",
-			"item": [
-				{
-					"name": "health",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"health.health\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/health",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"health"
-							]
-						},
-						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-getliveness)"
-					},
-					"response": []
-				}
-			],
-			"description": "This API can be used for measuring node health. [More info](https://docs.avax.network/v1.0/en/api/health)"
-		},
-		{
-			"name": "Index",
-			"item": [
-				{
-					"name": "X-Chain Transactions",
-					"item": [
-						{
-							"name": "getLastAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerRange",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
-							},
-							"response": []
-						},
-						{
-							"name": "getIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "isAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
-							},
-							"response": []
-						}
-					]
-				},
-				{
-					"name": "X-Chain Vertices",
-					"item": [
-						{
-							"name": "getLastAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerRange",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
-							},
-							"response": []
-						},
-						{
-							"name": "getIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"kLBLyNrBr9rjHFBScjvogspz167wrTD47SqbTsLk6YGGnjHwZ\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "isAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"kLBLyNrBr9rjHFBScjvogspz167wrTD47SqbTsLk6YGGnjHwZ\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
-							},
-							"response": []
-						}
-					]
-				},
-				{
-					"name": "P-Chain Blocks",
-					"item": [
-						{
-							"name": "getLastAccepted",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.environment.set(\"lastAcceptedPTxID\", pm.response.json().result.id)"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerRange",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
-							},
-							"response": []
-						},
-						{
-							"name": "getIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "isAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
-							},
-							"response": []
-						}
-					]
-				},
-				{
-					"name": "C-Chain Blocks",
-					"item": [
-						{
-							"name": "getLastAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerRange",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
-							},
-							"response": []
-						},
-						{
-							"name": "getIndex",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "isAccepted",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
-							},
-							"response": []
-						}
-					]
-				}
-			],
-			"description": "This API can be used to query data from AvalancheGo's database. The Index API is only available when node is run with --index-enabled option."
-		},
-		{
-			"name": "Info",
-			"item": [
-				{
-					"name": "getBlockchainID",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getBlockchainID\",\n    \"params\": {\n        \"alias\":\"X\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/build/avalanchego-apis/info#infogetblockchainid)"
-					},
-					"response": []
-				},
-				{
-					"name": "getNetworkID",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkID\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the ID of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnetworkid)"
-					},
-					"response": []
-				},
-				{
-					"name": "getNetworkName",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkName\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnetworkname)"
-					},
-					"response": []
-				},
-				{
-					"name": "getNodeID",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeID\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeid)"
-					},
-					"response": []
-				},
-				{
-					"name": "getNodeIP",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeIP\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the IP of this node. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeip)"
-					},
-					"response": []
-				},
-				{
-					"name": "getNodeVersion",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeVersion\",\n    \"params\" :{\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the version of this node. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeversion)"
-					},
-					"response": []
-				},
-				{
-					"name": "isBootstrapped",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.isBootstrapped\",\n    \"params\": {\n        \"chain\": \"X\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#infoisbootstrapped)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTxFee",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getTxFee\",\n    \"params\": {\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the transaction fee of the network. [More info](https://docs.avax.network/v1.0/en/api/info/#infogettxfee)"
-					},
-					"response": []
-				},
-				{
-					"name": "getVMs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getVMs\",\n    \"params\": {\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the virtual machines installed on this node. [More info](https://docs.avax.network/build/avalanchego-apis/info#infogetvms)"
-					},
-					"response": []
-				},
-				{
-					"name": "uptime",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.uptime\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Returns the network's observed uptime of this node. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#info-uptime)"
-					},
-					"response": []
-				},
-				{
-					"name": "peers",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.peers\",\n    \"params\" :{\n        \"nodeIDs\": []\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get description of peer connections. [More info](https://docs.avax.network/build/apis/info-api#info-peers)"
-					},
-					"response": []
-				}
-			],
-			"description": "This API can be used to access basic information about the node."
-		},
-		{
-			"name": "IPC",
-			"item": [
-				{
-					"name": "publishBlockchain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.publishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/ipcs",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"ipcs"
-							]
-						},
-						"description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-publishblockchain)"
-					},
-					"response": []
-				},
-				{
-					"name": "unpublishBlockchain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.unpublishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/ipcs",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"ipcs"
-							]
-						},
-						"description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-unpublishblockchain)"
-					},
-					"response": []
-				}
-			],
-			"description": "The IPC API allows users to create a UNIX domain socket for a blockchain to publish to. When the blockchain accepts a vertex/block it will publish the vertex to the socket.\n\nA node will only expose this API if it is started with command-line argument `api-ipcs-enabled=true`. [More info](https://docs.avax.network/v1.0/en/api/ipc/)"
-		},
-		{
-			"name": "Keystore",
-			"item": [
-				{
-					"name": "createUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Create a new user with the specified username and password. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-createuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "deleteUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.deleteUser\",\n    \"params\" : {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Delete a user. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-deleteuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-exportuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "importUser",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"user\"    :\"0x0000b79e54bb3452985874844fd02ce47671725850111b14d5b06d4b3e142ec852b39d1be2bdead684977bc0a1bfa6eeb06e000000040000004066687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f292500000000000000000000000000000000000000000000000000000000000000000000004c00000000002a92a15386259d71410fe602a9a1e2207a7afae3efd8d86f142577405476e5337a0736ba095b0fe911cb3100000018226dc5aec589008bc87ce142d5488d942f7e9d37374be99f0000003466687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f29253cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030b46ad90c1ef2f22282a9ab9c045cf190506148a7afcf4e94360e7e4109ef9abbc4aa97dd84533a5b081c0da489e205f00000001825e30947b222849b4f69b0a1eaf1dd49c82f5b64995d3c4e00000040faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de00000000000000000000000000000000000000000000000000000000000000000000004c00000000002a098545758bbf938acd508762ffff24bd2e8e0f80313fb0957c51fea30df6f304a94568c30dfb06257deb00000018e722d87e7d5964aa8a8772b0985d0723d398681ef29fad7900000034faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030722156f457680f16cf010d7cb3b350aaf210ae9ed58aaf89017f0046c5380ddf76fb944a6ff9a287a6a6e6c6303c751a000000183edfb66b8b01e6197507cde7e4909f816d3accf753155f96b346b48c\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-importuser)"
-					},
-					"response": []
-				},
-				{
-					"name": "listUsers",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.listUsers\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/keystore",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"keystore"
-							]
-						},
-						"description": "List the users in this keystore. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-listusers)"
-					},
-					"response": []
-				}
-			],
-			"description": "Every node has a built-in keystore. Clients create users on the keystore, which act as identities to be used when interacting with blockchains. A keystore exists at the node level, so if you create a user on a node it exists only on that node. However, users may be imported and exported using this API. \n\n**You should only create a keystore user on a node that you operate, as the node operator has access to your plaintext password.**\n\n[More info](https://docs.avax.network/v1.0/en/api/keystore)"
-		},
-		{
-			"name": "Metrics",
-			"item": [
-				{
-					"name": "metrics",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/metrics",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"metrics"
-							]
-						},
-						"description": "To get the node metrics. [More info](https://docs.avax.network/build/apis/metrics-api)"
-					},
-					"response": []
-				}
-			],
-			"description": "The API allows clients to get statistics about a node’s health and performance. [More info](https://docs.avax.network/v1.0/en/api/metrics/)"
-		},
-		{
-			"name": "PlatformVM",
-			"item": [
-				{
-					"name": "addDaoProposal",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDaoProposal\",\n    \"params\": {\n        \"proposalType\":1,\n        \"startTime\":0,\n        \"endTime\":600,\n        \"lockAmount\":1000000000,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"from\": [\"{{pchainAddress}}\"]\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "setAddressState",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"platform.setAddressState\",\n  \"params\" :{\n      \"from\":[\"{{kopernikusPchainAddress}}\"],\n      \"username\":\"{{avalancheUsername}}\",\n      \"password\":\"{{avalanchePassword}}\",\n      \"address\":\"{{kopernikusPchainAddress}}\",\n      \"state\": 34,\n      \"remove\": false\n  }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "registerNode",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.registerNode\",\n    \"params\": {\n        \"oldNodeID\": \"{{avalancheNodeId}}\",\n        \"newNodeID\": \"{{avalancheNodeId}}\",\n        \"consortiumMemberAddress\": \"{{kopernikusPchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "spend",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.spend\",\n    \"params\": {\n        \"lockMode\": 2,\n        \"amountToLock\": 10,\n        \"amountToBurn\": 1,\n        \"from\": [\"{{kopernikusPchainAddress}}\"],\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "getConfiguration",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getConfiguration\",\n    \"params\":{\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "getDaoProposal",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getDaoProposal\",\n    \"params\": {\n        \"daoProposalID\":\"{{daoProposalID}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "addDaoVote",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDaoVote\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"daoProposalID\":\"{{daoProposalID}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "addDelegator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
-					},
-					"response": []
-				},
-				{
-					"name": "addLock",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addLock\",\n    \"params\": {\n        \"startTime\":0,\n        \"endTime\":120,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
-					},
-					"response": []
-				},
-				{
-					"name": "addValidator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a validator to the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetvalidator)"
-					},
-					"response": []
-				},
-				{
-					"name": "addSubnetValidator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformaddnondefaultsubnetvalidator)"
-					},
-					"response": []
-				},
-				{
-					"name": "createAddress",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createAddress\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetdelegator)"
-					},
-					"response": []
-				},
-				{
-					"name": "createBlockchain",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Create a new blockchain. Currently only supports creation of new instances of the AVM and the Timestamp VM. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformcreateblockchain)"
-					},
-					"response": []
-				},
-				{
-					"name": "createSubnet",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Create an unsigned transaction to create a new Subnet.\n\nThe unsigned transaction must be signed with the key of the account paying the transaction fee.\n\nThe Subnet’s ID is the ID of the transaction that creates it (ie the response from `issueTx` when issuing the signed transaction. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformcreatesubnet)"
-					},
-					"response": []
-				},
-				{
-					"name": "getBalance",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"address\":\"{{pchainAddress}}\"    \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetbalance)"
-					},
-					"response": []
-				},
-				{
-					"name": "getBlockchains",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchains)"
-					},
-					"response": []
-				},
-				{
-					"name": "timestamp",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchains)"
-					},
-					"response": []
-				},
-				{
-					"name": "getBlockchainStatus",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchainStatus\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the status of a blockchain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchainstatus)"
-					},
-					"response": []
-				},
-				{
-					"name": "getCurrentSupply",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getCurrentSupply\",\n    \"params\": {}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns an upper bound on the number of AVAX that exist. This is an upper bound because it does not account for burnt tokens, including transaction fees. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentsupply)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTotalStake",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTotalStake\",\n    \"params\": {}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
-					},
-					"response": []
-				},
-				{
-					"name": "getCurrentValidators",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\":null,\n        \"nodeIDs\":[]\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
-					},
-					"response": []
-				},
-				{
-					"name": "getMaxStakeAmount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
-					},
-					"response": []
-				},
-				{
-					"name": "getHeight",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getHeight\",\n    \"params\": {}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the height of the last accepted block [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetheight)"
-					},
-					"response": []
-				},
-				{
-					"name": "getMinStake",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getMinStake\",\n    \"params\": {}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the minimum stake amount [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetminstake)"
-					},
-					"response": []
-				},
-				{
-					"name": "getRewardUTXOs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period ended."
-					},
-					"response": []
-				},
-				{
-					"name": "getStake",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the staked amount for an array of addresses [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstake)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTxStatus",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj\",\n        \"includeReason\": true\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the status of a platform chain transaction."
-					},
-					"response": []
-				},
-				{
-					"name": "getPendingValidators",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getPendingValidators\",\n    \"params\": {\n        \"subnetID\": null,\n        \"nodeIDs\": []\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetpendingvalidators)"
-					},
-					"response": []
-				},
-				{
-					"name": "getStakingAssetID",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Retrieve an assetID for a subnet’s staking asset. Currently this always returns the Primary Network’s staking assetID. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstakingassetid)"
-					},
-					"response": []
-				},
-				{
-					"name": "getSubnets",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {},\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get all the Subnets that exist. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetsubnets)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"{{lastAcceptedPTxID}}\",\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTimestamp",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTimestamp\",\n    \"params\" :{}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
-					},
-					"response": []
-				},
-				{
-					"name": "getTxStatus",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTxStatus\",\n    \"params\" :{\n        \"txID\":\"2C3AVShejyq6mLhEXvEGCnpaQi8tRwudBhSbT34hFiytffEFoe\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
-					},
-					"response": []
-				},
-				{
-					"name": "getUTXOs",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{pchainAddress}}\"],\n        \"sourceChain\": \"P\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
-					},
-					"response": []
-				},
-				{
-					"name": "getValidatorsAt",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getValidatorsAt\",\n    \"params\" :{\n        \"height\": 0,\n        \"subnetID\": \"11111111111111111111111111111111LpoYY\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the validators and their weights of a subnet or the Primary Network at a given P-Chain height. [More info](https://docs.avax.network/build/avalanchego-apis/platform-chain-p-chain-api#platform-getvalidatorsat)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "importAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Complete a transfer of AVAX from the X-Chain to the C-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.avax.network/v1.0/en/api/platform/#avmimportava)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformimportkey)"
-					},
-					"response": []
-				},
-				{
-					"name": "issueTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.issueTx\",\n    \"params\": {\n        \"tx\":\"0x00\",\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Issue a transaction to the Platform Chain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformissuetx)"
-					},
-					"response": []
-				},
-				{
-					"name": "listAddresses",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.listAddresses\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the addresses controlled by the given user. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformlistaddresses)"
-					},
-					"response": []
-				},
-				{
-					"name": "sampleValidators",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.sampleValidators\",\n    \"params\" :{\n        \"size\":2\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Sample validators from the specified Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformsamplevalidators)"
-					},
-					"response": []
-				},
-				{
-					"name": "validatedBy",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.validatedBy\",\n    \"params\": {\n        \"blockchainID\": \"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the Subnet that validates a given blockchain. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformvalidatedby)"
-					},
-					"response": []
-				},
-				{
-					"name": "validates",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.validates\",\n    \"params\": {\n        \"subnetID\":\"{{avalancheSubnetId}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the IDs of the blockchains a Subnet validates. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformvalidates)"
-					},
-					"response": []
-				}
-			],
-			"description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Avalanche’s validator set and handles blockchain creation. [More info](https://docs.avax.network/v1.0/en/api/platform)"
-		}
-	]
+  "info": {
+    "_postman_id": "89c2c02e-22ee-4188-a8bf-659ff88a358a",
+    "name": "Camino",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "16493174"
+  },
+  "item": [
+    {
+      "name": "Admin",
+      "item": [
+        {
+          "name": "alias",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.alias\",\n    \"params\": {\n        \"alias\":\"myAlias\",\n        \"endpoint\":\"bc/X\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminalias)"
+          },
+          "response": []
+        },
+        {
+          "name": "getNodeSigner",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getNodeSigner\",\n    \"params\": {\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "NodeID generation from node's key implementation . [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#getnodesigner)"
+          },
+          "response": []
+        },
+        {
+          "name": "aliasChain",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.aliasChain\",\n    \"params\": {\n        \"chain\":\"{{caminoBlockchainId}}\",\n        \"alias\":\"myBlockchainAlias\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminaliaschain)"
+          },
+          "response": []
+        },
+        {
+          "name": "getChainAliases",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getChainAliases\",\n    \"params\" :{\n        \"chain\":\"2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#admingetchainaliases)"
+          },
+          "response": []
+        },
+        {
+          "name": "getLoggerLevel",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getLoggerLevel\",\n    \"params\" :{\n        \"loggerName\":\"C\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Returns log and display levels of loggers. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#admingetloggerlevel)"
+          },
+          "response": []
+        },
+        {
+          "name": "loadVMs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.loadVMs\",\n    \"params\" :{}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Dynamically loads any virtual machines installed on the node as plugins. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminloadvms)"
+          },
+          "response": []
+        },
+        {
+          "name": "lockProfile",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.lockProfile\",\n    \"params\" :{}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminlockprofile)"
+          },
+          "response": []
+        },
+        {
+          "name": "memoryProfile",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.memoryProfile\",\n    \"params\" :{}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminmemoryprofile)"
+          },
+          "response": []
+        },
+        {
+          "name": "setLoggerLevel",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.setLoggerLevel\",\n    \"params\" :{\n        \"loggerName\": \"C\",\n        \"logLevel\": \"DEBUG\",\n        \"displayLevel\": \"INFO\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Sets log and display levels of loggers. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminsetloggerlevel)"
+          },
+          "response": []
+        },
+        {
+          "name": "startCPUProfiler",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.startCPUProfiler\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Start profiling the CPU utilization of the node. Will write the profile to the specified file on stop. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminstartcpuprofiler)"
+          },
+          "response": []
+        },
+        {
+          "name": "stopCPUProfiler",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.stopCPUProfiler\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/admin",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "admin"]
+            },
+            "description": "Stop the CPU profile that was previously started. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin#adminstopcpuprofiler)"
+          },
+          "response": []
+        }
+      ],
+      "description": "This API can be used for measuring node health and debugging. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/admin)"
+    },
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "newToken",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.newToken\",\n    \"params\": {\n        \"password\":\"{{authPassword}}\",\n        \"endpoints\":[\"/ext/bc/X\", \"/ext/info\"]\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/auth",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "auth"]
+            },
+            "description": "Creates a new authorization token that grants access to one or more API endpoints.\n [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/auth#authnewtoken)"
+          },
+          "response": []
+        },
+        {
+          "name": "revokeToken",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.revokeToken\",\n    \"params\": {\n        \"password\":\"password goes here\",\n        \"token\":\"token goes here\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/auth",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "auth"]
+            },
+            "description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.\nIf the token is invalid, does nothing. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/auth#authrevoketoken)"
+          },
+          "response": []
+        },
+        {
+          "name": "changePassword",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.changePassword\",\n    \"params\": {\n        \"oldPassword\":\"old password goes here\",\n        \"newPassword\":\"new password goes here\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/auth",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "auth"]
+            },
+            "description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/auth#authchangepassword)"
+          },
+          "response": []
+        }
+      ],
+      "description": "When you run a node, you can require that API calls have an authorization token attached. This API manages the creation and revocation of authorization tokens. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/auth)"
+    },
+    {
+      "name": "AVM",
+      "item": [
+        {
+          "name": "buildGenesis",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 1337,\n        \"encoding\":\"cb58\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/vm/avm",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "vm", "avm"]
+            },
+            "description": "Given a JSON representation of this Virtual Machine’s genesis state, create the byte representation of that state. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmbuildgenesis)"
+          },
+          "response": []
+        },
+        {
+          "name": "createAddress",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.createAddress\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Create a new address controlled by the given user. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmcreateaddress)"
+          },
+          "response": []
+        },
+        {
+          "name": "createAsset",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmcreatefixedcapasset)"
+          },
+          "response": []
+        },
+        {
+          "name": "createFixedCapAsset",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"denomination\": 0,  \n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmcreatefixedcapasset)"
+          },
+          "response": []
+        },
+        {
+          "name": "createNFTAsset",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmcreatenftasset)"
+          },
+          "response": []
+        },
+        {
+          "name": "createVariableCapAsset",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmcreatevariablecapasset)"
+          },
+          "response": []
+        },
+        {
+          "name": "export",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000         ,\n        \"assetID\": \"AVAX\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmexport)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportAVAX",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"C\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmexportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmexportkey)"
+          },
+          "response": []
+        },
+        {
+          "name": "getAddressTxs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Returns all transactions that change the balance of the given address. A transaction is said to change an address's balance if either is true:\n\n*   A UTXO that the transaction consumes was at least partially owned by the address.\n*   A UTXO that the transaction produces is at least partially owned by the address.\n    \n\nNote: Indexing (`index-transactions`) must be enabled in the X-chain config. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmgetaddresstxs)"
+          },
+          "response": []
+        },
+        {
+          "name": "getAllBalances",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Get the balances of all assets controlled by a given address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmgetallbalances)"
+          },
+          "response": []
+        },
+        {
+          "name": "getAssetDescription",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getAssetDescription\",\n    \"params\" :{\n        \"assetID\" :\"{{camAssetId}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Get information about an asset. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmgetassetdescription)"
+          },
+          "response": []
+        },
+        {
+          "name": "getBalance",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var template = `",
+                  "    <table bgcolor=\"#FFFFFF\">",
+                  "        <tr>",
+                  "            <th>Name</th>",
+                  "            <th>Email</th>",
+                  "        </tr>",
+                  "",
+                  "        {{#each response}}",
+                  "            <tr>",
+                  "                <td>{{name}}</td>",
+                  "                <td>{{email}}</td>",
+                  "            </tr>",
+                  "        {{/each}}",
+                  "    </table>",
+                  "`;",
+                  "",
+                  "// Set visualizer",
+                  "pm.visualizer.set(template, {",
+                  "    // Pass the response body parsed as JSON as `data`",
+                  "    response: pm.response.json()",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"avm.getBalance\",\n  \"params\" :{\n      \"address\":\"{{xchainAddress}}\",\n      \"assetID\": \"{{camAssetId}}\"\n  }\n} ",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Get the balance of an asset controlled by a given address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmgetbalance)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTx",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTx\",\n    \"params\" :{\n        \"txID\":\"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Returns the specified transaction [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmgettx)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTxStatus",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"2HHr7xUJgWiLESV7g8T3oWfWvdpWJXd4Hctj6U3KhzUN6EsgBG\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Get the status of a transaction sent to the network. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmgettxstatus)"
+          },
+          "response": []
+        },
+        {
+          "name": "getUTXOs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Get the UTXOs that reference a given address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avm-getutxos)"
+          },
+          "response": []
+        },
+        {
+          "name": "import",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.import\",\n    \"params\" :{\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmimportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "importAVAX",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"sourceChain\": \"C\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmimportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "issueTx",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.issueTx\",\n    \"params\" :{\n        \"tx\":\"6sTENqXfk3gahxkJbEPsmX9eJTEFZRSRw83cRJqoHWBiaeAhVbz9QV4i6SLd6Dek4eLsojeR8FbT3arFtsGz9ycpHFaWHLX69edJPEmj2tPApsEqsFd7wDVp7fFxkG6HmySR\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Send a signed transaction to the network. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmissuetx)"
+          },
+          "response": []
+        },
+        {
+          "name": "importKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmimportkey)"
+          },
+          "response": []
+        },
+        {
+          "name": "listAddresses",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.listAddresses\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "List addresses controlled by the given user. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmlistaddresses)"
+          },
+          "response": []
+        },
+        {
+          "name": "mint",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmmint)"
+          },
+          "response": []
+        },
+        {
+          "name": "mintNFT",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" ,\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmmintnft)"
+          },
+          "response": []
+        },
+        {
+          "name": "send",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{camAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Send a quantity of an asset to an address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmsend)"
+          },
+          "response": []
+        },
+        {
+          "name": "sendAsManager",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendAsManager\",\n    \"params\" :{ \n        \"assetID\" : \"{{camAssetId}}\",\n        \"amount\"  : 2000000,\n        \"feeFrom\": [\"{{xchainAddress}}\"],\n        \"feeChangeAddr\": \"{{xchainAddress}}\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Send a quantity of an asset to an address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmsend)"
+          },
+          "response": []
+        },
+        {
+          "name": "sendMultiple",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendMultiple\",\n    \"params\" :{ \n        \"outputs\": [\n            {\n                \"assetID\" : \"{{camAssetId}}\",\n                \"to\"      : \"{{xchainAddress}}\",\n                \"amount\"  : 1000000000\n            }\n        ],\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Send a quantity of an asset to an address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmsendmultiple)"
+          },
+          "response": []
+        },
+        {
+          "name": "sendNFT",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Send a quantity of an asset to an address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmsendnft)"
+          },
+          "response": []
+        },
+        {
+          "name": "updateManagedAsset",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.updateManagedAsset\",\n    \"params\" :{ \n        \"assetID\" : {{camAssetId}},\n        \"frozen\": true,\n        \"manager\":{\n            \"threshold\": 1,\n            \"addresses\": [\n                \"{{xchainAddress}}\"\n            ]\n        },\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\" \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/X",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "X"]
+            },
+            "description": "Send a quantity of an asset to an address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmsend)"
+          },
+          "response": []
+        }
+      ],
+      "description": "The X-Chain, Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.avax.network/v1.0/en/api/avm)"
+    },
+    {
+      "name": "EVM",
+      "item": [
+        {
+          "name": "eth_baseFee",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_baseFee\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Get the base fee for the next block. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#eth_baseFee)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_blockNumber",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_blockNumber\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting the most recent block number. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#getting-the-most-recent-block-number)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_call",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_call\",\n    \"params\": [\n        {\n            \"to\": \"0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7\",\n            \"data\": \"0xc92aecc4\"\n        },\n        \"latest\"\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Call a contract. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#call-a-contract)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_chainId",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_chainId\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Not well documented in JSON-RPC references. See instead EIP694. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#getting-the-chain-id)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getAssetBalance",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getAssetBalance\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\",\n        \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting an account’s non-AVAX balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-non-avax-balance)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getBalance",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting an account’s balance. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#getting-an-accounts-balance)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_maxPriorityFeePerGas",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_maxPriorityFeePerGas\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Get the priority fee needed to be included in a block. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#eth_maxPriorityFeePerGas)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_signTransaction",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_signTransaction\",\n    \"params\": [{\n        \"from\": \"0xa64b27635c967dfe9674926bc004626163ddce97\",\n        \"to\": \"0x1c5b0e12e90e9c52235babad76cfccab2519bb95\",\n        \"gas\": \"0x5208\",\n        \"gasPrice\": \"0x0\",\n        \"nonce\": \"0x0\",\n        \"value\": \"0x0\"\n    }],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#signing-a-transaction)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getTransactionCount",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting an account’s nonce. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#getting-an-accounts-nonce)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_sendRawTransaction",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_sendRawTransaction\",\n    \"params\": [\n        \"0xf8628080825208941c5b0e12e90e9c52235babad76cfccab2519bb958080830150efa0308ca8002f3df1a468eea9973d2d618eb866e2ef0a57cba4d34efb3025b70a0aa0592b7b0a803e7b70ec26dd74ab85aa71126198eff5552e5be638e6e26a455ee0\"\n    ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#send-a-raw-transaction)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getBlockByHash",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBlockByHash\",\n    \"params\": [\n        \"0x14d9c2aeec20254d966a947e23eb3172ae5067e66fd4e69aecc3c9d6ff24443a\",\n        true\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting a block by hash. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/contract-chain-c-chain-api#getting-a-block-by-hash)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getBlockByNumber",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBlockByNumber\",\n    \"params\": [\n        \"0x5\",\n        true\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting a block by number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-block-by-number)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getTransactionByHash",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionByHash\",\n    \"params\": [\n        \"0xd33150a3f3783f29084eee4e12098f3ef707557f8deb916677a9af68e05613b7\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting a transaction by hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-by-hash)"
+          },
+          "response": []
+        },
+        {
+          "name": "eth_getTransactionReceipt",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionReceipt\",\n    \"params\": [\n        \"0xd33150a3f3783f29084eee4e12098f3ef707557f8deb916677a9af68e05613b7\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting a transaction receipt. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-receipt)"
+          },
+          "response": []
+        },
+        {
+          "name": "export",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"method\" :\"avax.export\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 25,\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"assetID\": \"FSznYPiqrJ3WtGurw54re47oDpGXQ8THc8yZ4fEDX4G8cGqbn\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportAVAX",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"method\" :\"avax.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 999000000,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"method\" :\"avax.exportKey\",\n    \"params\" :{\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"address\": \"{{cchainAddress}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportkey)\n\n"
+          },
+          "response": []
+        },
+        {
+          "name": "getAtomicTx",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+          },
+          "response": []
+        },
+        {
+          "name": "getAtomicTxStatus",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getAtomicTxStatus\",\n    \"params\": {\n        \"txID\": \"n1D9UkjiryEBtW8qznD1TDkGEuYRFj5tLaS8NhVpMLYsx1FHa\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgettxstatus)"
+          },
+          "response": []
+        },
+        {
+          "name": "getUTXOs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{cchainbech32address}}\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+          },
+          "response": []
+        },
+        {
+          "name": "import",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"method\": \"avax.import\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "importAVAX",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Import AVAX from the X-Chain to an account on the C-Chain.\nBefore calling this method, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/evm/#evmimportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "importKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
+          },
+          "response": []
+        },
+        {
+          "name": "issueTx",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avax.issueTx\",\n    \"params\" :{\n        \"tx\":\"0x00\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/avax",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "avax"]
+            },
+            "description": "Send a signed transaction to the network. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avmissuetx)"
+          },
+          "response": []
+        },
+        {
+          "name": "net_version",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_version\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting the network ID. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-network-id)"
+          },
+          "response": []
+        },
+        {
+          "name": "personal_newAccount",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_newAccount\",\n    \"params\": [\n        \"cheese\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Creating a new account (private key generated automatically)\n\nThe EVM will create a new account using the passphrase `cheese` to encrypt and store the new account credentials. cheese is not the seed phrase and cannot be used to restore this account from scratch. Calling this function repeatedly with the same passphrase will create multiple unique accounts. Also keep in mind there are no options to export private keys stored in the EVM database. Users are encouraged to use wallet software instead for safer account creation and backup. This method is more suitable for quick account creation for a testnet."
+          },
+          "response": []
+        },
+        {
+          "name": "personal_importRawKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_importRawKey\",\n    \"params\": [\n        \"627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d07\",\n        \"{{cchainPassphrase}}\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Creating a new account (using plaintext private key).\n\nIf the private key is known upfront, it can be provided as plaintext to load into the EVM account database. For more secure account management, consider using wallet software instead. The example below loads the private key `0x627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d06` with the passphrase `this is my passphrase`. Note that `0x` prefix cannot be included in the private key argument, otherwise the EVM will throw an error. The example response returns the associated public key."
+          },
+          "response": []
+        },
+        {
+          "name": "personal_listAccounts",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_listAccounts\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Listing accounts loaded in EVM node. [More info](https://docs.avax.network/v1.0/en/api/evm/#listing-accounts-loaded-in-evm-node)"
+          },
+          "response": []
+        },
+        {
+          "name": "personal_unlockAccount",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_unlockAccount\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"{{cchainPassphrase}}\",\n        600\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.avax.network/v1.0/en/api/evm/#unlocking-an-account)"
+          },
+          "response": []
+        },
+        {
+          "name": "txpool_status",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"txpool_status\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-count-of-pending-transactions)"
+          },
+          "response": []
+        },
+        {
+          "name": "web3_clientVersion",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_clientVersion\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Getting the current client version. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-current-client-version)"
+          },
+          "response": []
+        },
+        {
+          "name": "web3_sha3",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_sha3\",\n    \"params\": [\n        \"0x736e6f7773746f726d\"\n    ],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/C/rpc",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "C", "rpc"]
+            },
+            "description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
+          },
+          "response": []
+        }
+      ],
+      "description": "This document describes the API of the C-Chain, which is an instance of the Ethereum Virtual Machine (EVM.)\n\nNote: Ethereum has its own notion of `networkID` and `chainID`. The C-Chain uses `1` and `43110` for these values, obtained using the `net_version` and `eth_chainId` methods shown below. These have no relationship to AVA’s view of networkID and chainID, and are purely internal to the C-Chain. [More info](https://docs.avax.network/v1.0/en/api/evm)"
+    },
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "health",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"health.health\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/health",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "health"]
+            },
+            "description": "Get health check on this node. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/health#healthhealth)"
+          },
+          "response": []
+        }
+      ],
+      "description": "This API can be used for measuring node health. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/health)"
+    },
+    {
+      "name": "Index",
+      "item": [
+        {
+          "name": "X-Chain Transactions",
+          "item": [
+            {
+              "name": "getLastAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/tx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "tx"]
+                },
+                "description": "Get the most recently accepted container. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetlastaccepted)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/tx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "tx"]
+                },
+                "description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByID",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/tx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "tx"]
+                },
+                "description": "Get container by ID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyid)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerRange",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/tx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "tx"]
+                },
+                "description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerrange)"
+              },
+              "response": []
+            },
+            {
+              "name": "getIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/tx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "tx"]
+                },
+                "description": "Get a container's index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "isAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/tx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "tx"]
+                },
+                "description": "Returns true if the container is in this index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexisaccepted)"
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "X-Chain Vertices",
+          "item": [
+            {
+              "name": "getLastAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/vtx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "vtx"]
+                },
+                "description": "Get the most recently accepted container. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetlastaccepted)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/vtx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "vtx"]
+                },
+                "description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByID",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/vtx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "vtx"]
+                },
+                "description": "Get container by ID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyid)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerRange",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/vtx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "vtx"]
+                },
+                "description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerrange)"
+              },
+              "response": []
+            },
+            {
+              "name": "getIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"kLBLyNrBr9rjHFBScjvogspz167wrTD47SqbTsLk6YGGnjHwZ\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/vtx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "vtx"]
+                },
+                "description": "Get a container's index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "isAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"kLBLyNrBr9rjHFBScjvogspz167wrTD47SqbTsLk6YGGnjHwZ\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/X/vtx",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "X", "vtx"]
+                },
+                "description": "Returns true if the container is in this index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexisaccepted)"
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "P-Chain Blocks",
+          "item": [
+            {
+              "name": "getLastAccepted",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.environment.set(\"lastAcceptedPTxID\", pm.response.json().result.id)"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/P/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "P", "block"]
+                },
+                "description": "Get the most recently accepted container. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetlastaccepted)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/P/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "P", "block"]
+                },
+                "description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByID",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/P/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "P", "block"]
+                },
+                "description": "Get container by ID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyid)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerRange",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/P/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "P", "block"]
+                },
+                "description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerrange)"
+              },
+              "response": []
+            },
+            {
+              "name": "getIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/P/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "P", "block"]
+                },
+                "description": "Get a container's index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "isAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/P/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "P", "block"]
+                },
+                "description": "Returns true if the container is in this index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexisaccepted)"
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "C-Chain Blocks",
+          "item": [
+            {
+              "name": "getLastAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/C/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "C", "block"]
+                },
+                "description": "Get the most recently accepted container. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetlastaccepted)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/C/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "C", "block"]
+                },
+                "description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerByID",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/C/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "C", "block"]
+                },
+                "description": "Get container by ID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerbyid)"
+              },
+              "response": []
+            },
+            {
+              "name": "getContainerRange",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/C/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "C", "block"]
+                },
+                "description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetcontainerrange)"
+              },
+              "response": []
+            },
+            {
+              "name": "getIndex",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/C/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "C", "block"]
+                },
+                "description": "Get a container's index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexgetindex)"
+              },
+              "response": []
+            },
+            {
+              "name": "isAccepted",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseURL}}/ext/index/C/block",
+                  "host": ["{{baseURL}}"],
+                  "path": ["ext", "index", "C", "block"]
+                },
+                "description": "Returns true if the container is in this index. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/index-api#indexisaccepted)"
+              },
+              "response": []
+            }
+          ]
+        }
+      ],
+      "description": "This API can be used to query data from AvalancheGo's database. The Index API is only available when node is run with --index-enabled option."
+    },
+    {
+      "name": "Info",
+      "item": [
+        {
+          "name": "getBlockchainID",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getBlockchainID\",\n    \"params\": {\n        \"alias\":\"X\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Given a blockchain’s alias, get its ID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetblockchainid)"
+          },
+          "response": []
+        },
+        {
+          "name": "getNetworkID",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkID\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the ID of the network this node is participating in. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetnetworkid)"
+          },
+          "response": []
+        },
+        {
+          "name": "getNetworkName",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkName\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the name of the network this node is participating in. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetnetworkname)"
+          },
+          "response": []
+        },
+        {
+          "name": "getNodeID",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeID\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the name of the network this node is participating in. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetnodeid)"
+          },
+          "response": []
+        },
+        {
+          "name": "getNodeIP",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeIP\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the IP of this node. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetnodeip)"
+          },
+          "response": []
+        },
+        {
+          "name": "getNodeVersion",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeVersion\",\n    \"params\" :{\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the version of this node. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetnodeversion)"
+          },
+          "response": []
+        },
+        {
+          "name": "isBootstrapped",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.isBootstrapped\",\n    \"params\": {\n        \"chain\": \"X\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Check whether a given chain is done bootstrapping. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info/#infoisbootstrapped)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTxFee",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getTxFee\",\n    \"params\": {\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the transaction fee of the network. [More info](https://docs.avax.network/v1.0/en/api/info/#infogettxfee)"
+          },
+          "response": []
+        },
+        {
+          "name": "getVMs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getVMs\",\n    \"params\": {\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get the virtual machines installed on this node. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infogetvms)"
+          },
+          "response": []
+        },
+        {
+          "name": "uptime",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.uptime\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Returns the network's observed uptime of this node. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info/#infouptime)"
+          },
+          "response": []
+        },
+        {
+          "name": "peers",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.peers\",\n    \"params\" :{\n        \"nodeIDs\": []\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/info",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "info"]
+            },
+            "description": "Get description of peer connections. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/info#infopeers)"
+          },
+          "response": []
+        }
+      ],
+      "description": "This API can be used to access basic information about the node."
+    },
+    {
+      "name": "IPC",
+      "item": [
+        {
+          "name": "publishBlockchain",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.publishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{caminoBlockchainId}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/ipcs",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "ipcs"]
+            },
+            "description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/ipc#ipcspublishblockchain)"
+          },
+          "response": []
+        },
+        {
+          "name": "unpublishBlockchain",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.unpublishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{caminoBlockchainId}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/ipcs",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "ipcs"]
+            },
+            "description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/ipc#ipcsunpublishblockchain)"
+          },
+          "response": []
+        }
+      ],
+      "description": "The IPC API allows users to create a UNIX domain socket for a blockchain to publish to. When the blockchain accepts a vertex/block it will publish the vertex to the socket.\n\nA node will only expose this API if it is started with command-line argument `api-ipcs-enabled=true`. [More info](https://docs.avax.network/v1.0/en/api/ipc/)"
+    },
+    {
+      "name": "Keystore",
+      "item": [
+        {
+          "name": "createUser",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/keystore",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "keystore"]
+            },
+            "description": "Create a new user with the specified username and password. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystorecreateuser)"
+          },
+          "response": []
+        },
+        {
+          "name": "deleteUser",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.deleteUser\",\n    \"params\" : {\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/keystore",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "keystore"]
+            },
+            "description": "Delete a user. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystoredeleteuser)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportUser",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/keystore",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "keystore"]
+            },
+            "description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystoreexportuser)"
+          },
+          "response": []
+        },
+        {
+          "name": "importUser",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\",\n        \"user\"    :\"0x0000b79e54bb3452985874844fd02ce47671725850111b14d5b06d4b3e142ec852b39d1be2bdead684977bc0a1bfa6eeb06e000000040000004066687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f292500000000000000000000000000000000000000000000000000000000000000000000004c00000000002a92a15386259d71410fe602a9a1e2207a7afae3efd8d86f142577405476e5337a0736ba095b0fe911cb3100000018226dc5aec589008bc87ce142d5488d942f7e9d37374be99f0000003466687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f29253cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030b46ad90c1ef2f22282a9ab9c045cf190506148a7afcf4e94360e7e4109ef9abbc4aa97dd84533a5b081c0da489e205f00000001825e30947b222849b4f69b0a1eaf1dd49c82f5b64995d3c4e00000040faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de00000000000000000000000000000000000000000000000000000000000000000000004c00000000002a098545758bbf938acd508762ffff24bd2e8e0f80313fb0957c51fea30df6f304a94568c30dfb06257deb00000018e722d87e7d5964aa8a8772b0985d0723d398681ef29fad7900000034faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030722156f457680f16cf010d7cb3b350aaf210ae9ed58aaf89017f0046c5380ddf76fb944a6ff9a287a6a6e6c6303c751a000000183edfb66b8b01e6197507cde7e4909f816d3accf753155f96b346b48c\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/keystore",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "keystore"]
+            },
+            "description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystoreimportuser)"
+          },
+          "response": []
+        },
+        {
+          "name": "listUsers",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.listUsers\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/keystore",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "keystore"]
+            },
+            "description": "List the users in this keystore. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystorelistusers)"
+          },
+          "response": []
+        }
+      ],
+      "description": "Every node has a built-in keystore. Clients create users on the keystore, which act as identities to be used when interacting with blockchains. A keystore exists at the node level, so if you create a user on a node it exists only on that node. However, users may be imported and exported using this API. \n\n**You should only create a keystore user on a node that you operate, as the node operator has access to your plaintext password.**\n\n[More info](https://docs.avax.network/v1.0/en/api/keystore)"
+    },
+    {
+      "name": "Metrics",
+      "item": [
+        {
+          "name": "metrics",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": ""
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/metrics",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "metrics"]
+            },
+            "description": "To get the node metrics. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/metrics)"
+          },
+          "response": []
+        }
+      ],
+      "description": "The API allows clients to get statistics about a node’s health and performance. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/metrics)"
+    },
+    {
+      "name": "PlatformVM",
+      "item": [
+        {
+          "name": "setAddressState",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"platform.setAddressState\",\n  \"params\" :{\n      \"from\":[\"{{pchainAddress}}\"],\n      \"username\":\"{{caminoUserName}}\",\n      \"password\":\"{{caminoPassword}}\",\n      \"address\":\"{{pchainAddress}}\",\n      \"state\": 34,\n      \"remove\": false\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Issues an AddressStateTx transaction which assigns state to an address. (https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformsetaddressstate)"
+          },
+          "response": []
+        },
+        {
+          "name": "registerNode",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.registerNode\",\n    \"params\": {\n        \"oldNodeID\": \"{{caminoNodeId}}\",\n        \"newNodeID\": \"{{caminoNodeId}}\",\n        \"consortiumMemberAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Map/unmap new/old nodeIDs to consortium members. (https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformregisternode)"
+          },
+          "response": []
+        },
+        {
+          "name": "spend",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.spend\",\n    \"params\": {\n        \"lockMode\": 2,\n        \"amountToLock\": 10,\n        \"amountToBurn\": 1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Handles inputs/outputs generation for burn/lock tokens operation. (https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystorelistusers)"
+          },
+          "response": []
+        },
+        {
+          "name": "getConfiguration",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getConfiguration\",\n    \"params\":{\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "returns platformVM configuration. (https://docs.camino.foundation/developer/apis/camino-node-apis/keystore#keystorelistusers)"
+          },
+          "response": []
+        },
+        {
+          "name": "addDelegator",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{caminoNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n   \"from\": [\"{{pchainAddress}}\"],\n      \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformadddefaultsubnetdelegator)"
+          },
+          "response": []
+        },
+        {
+          "name": "addLock",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addLock\",\n    \"params\": {\n        \"startTime\":0,\n        \"endTime\":120,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformadddefaultsubnetdelegator)"
+          },
+          "response": []
+        },
+        {
+          "name": "addValidator",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{caminoNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n    \"from\": [\"{{pchainAddress}}\"],\n      \"delegationFeeRate\":10,\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Add a validator to the Default Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformadddefaultsubnetvalidator)"
+          },
+          "response": []
+        },
+        {
+          "name": "addSubnetValidator",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{caminoNodeId}}\",\n        \"subnetID\":\"{{caminoSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformaddnondefaultsubnetvalidator)"
+          },
+          "response": []
+        },
+        {
+          "name": "createAddress",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createAddress\",\n    \"params\": {\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Add a delegator to the Default Subnet.\n\nA delegator stakes AVAX and specifies a validator (the delegatee) to validate on their behalf. The delegatee has an increased probability of being sampled by other validators (weight) in proportion to the stake delegated to them.\n\nThe delegatee charges a fee to the delegator; the former receives a percentage of the delegator’s validation reward (if any.)\n\nThe delegation period must be a subset of the perdiod that the delegatee validates the Default Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformadddefaultsubnetdelegator)"
+          },
+          "response": []
+        },
+        {
+          "name": "createBlockchain",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{caminoSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Create a new blockchain. Currently only supports creation of new instances of the AVM and the Timestamp VM. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformcreateblockchain)"
+          },
+          "response": []
+        },
+        {
+          "name": "createSubnet",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Create an unsigned transaction to create a new Subnet.\n\nThe unsigned transaction must be signed with the key of the account paying the transaction fee.\n\nThe Subnet’s ID is the ID of the transaction that creates it (ie the response from `issueTx` when issuing the signed transaction. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformcreatesubnet)"
+          },
+          "response": []
+        },
+        {
+          "name": "getBalance",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"address\":\"{{pchainAddress}}\"    \n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the balance of an asset controlled by a given address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetbalance)"
+          },
+          "response": []
+        },
+        {
+          "name": "getBlockchains",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetblockchains)"
+          },
+          "response": []
+        },
+        {
+          "name": "timestamp",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetblockchains)"
+          },
+          "response": []
+        },
+        {
+          "name": "getBlockchainStatus",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchainStatus\",\n    \"params\":{\n        \"blockchainID\":\"{{caminoBlockchainId}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the status of a blockchain. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetblockchainstatus)"
+          },
+          "response": []
+        },
+        {
+          "name": "getCurrentSupply",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getCurrentSupply\",\n    \"params\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns an upper bound on the number of AVAX that exist. This is an upper bound because it does not account for burnt tokens, including transaction fees. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetcurrentsupply)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTotalStake",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTotalStake\",\n    \"params\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
+          },
+          "response": []
+        },
+        {
+          "name": "getCurrentValidators",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\":null,\n        \"nodeIDs\":[]\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "List the current validators of the given Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetcurrentvalidators)"
+          },
+          "response": []
+        },
+        {
+          "name": "getMaxStakeAmount",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "List the current validators of the given Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetcurrentvalidators)"
+          },
+          "response": []
+        },
+        {
+          "name": "getHeight",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getHeight\",\n    \"params\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the height of the last accepted block [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetheight)"
+          },
+          "response": []
+        },
+        {
+          "name": "getMinStake",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getMinStake\",\n    \"params\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the minimum stake amount [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetminstake)"
+          },
+          "response": []
+        },
+        {
+          "name": "getRewardUTXOs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period ended."
+          },
+          "response": []
+        },
+        {
+          "name": "getStake",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the staked amount for an array of addresses [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetstake)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTxStatus",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj\",\n        \"includeReason\": true\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the status of a platform chain transaction."
+          },
+          "response": []
+        },
+        {
+          "name": "getPendingValidators",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getPendingValidators\",\n    \"params\": {\n        \"subnetID\": null,\n        \"nodeIDs\": []\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetpendingvalidators)"
+          },
+          "response": []
+        },
+        {
+          "name": "getStakingAssetID",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Retrieve an assetID for a subnet’s staking asset. Currently this always returns the Primary Network’s staking assetID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetstakingassetid)"
+          },
+          "response": []
+        },
+        {
+          "name": "getSubnets",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {},\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get all the Subnets that exist. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetsubnets)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTx",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"{{lastAcceptedPTxID}}\",\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTimestamp",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTimestamp\",\n    \"params\" :{}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+          },
+          "response": []
+        },
+        {
+          "name": "getTxStatus",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTxStatus\",\n    \"params\" :{\n        \"txID\":\"2C3AVShejyq6mLhEXvEGCnpaQi8tRwudBhSbT34hFiytffEFoe\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+          },
+          "response": []
+        },
+        {
+          "name": "getUTXOs",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{pchainAddress}}\"],\n        \"sourceChain\": \"P\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the UTXOs that reference a given address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetutxos)"
+          },
+          "response": []
+        },
+        {
+          "name": "getValidatorsAt",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getValidatorsAt\",\n    \"params\" :{\n        \"height\": 0,\n        \"subnetID\": \"11111111111111111111111111111111LpoYY\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the validators and their weights of a subnet or the Primary Network at a given P-Chain height. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetvalidatorsat)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportAVAX",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformexportavax)"
+          },
+          "response": []
+        },
+        {
+          "name": "exportKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformexportkey)"
+          },
+          "response": []
+        },
+        {
+          "name": "importAVAX",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Complete a transfer of AVAX from the X-Chain to the C-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#avmimportava)"
+          },
+          "response": []
+        },
+        {
+          "name": "importKey",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformimportkey)"
+          },
+          "response": []
+        },
+        {
+          "name": "issueTx",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.issueTx\",\n    \"params\": {\n        \"tx\":\"0x00\",\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Issue a transaction to the Platform Chain. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformissuetx)"
+          },
+          "response": []
+        },
+        {
+          "name": "listAddresses",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.listAddresses\",\n    \"params\": {\n        \"username\": \"{{caminoUserName}}\",\n        \"password\": \"{{caminoPassword}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "List the addresses controlled by the given user. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformlistaddresses)"
+          },
+          "response": []
+        },
+        {
+          "name": "sampleValidators",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.sampleValidators\",\n    \"params\" :{\n        \"size\":2\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Sample validators from the specified Subnet. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformsamplevalidators)"
+          },
+          "response": []
+        },
+        {
+          "name": "validatedBy",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.validatedBy\",\n    \"params\": {\n        \"blockchainID\": \"{{caminoBlockchainId}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the Subnet that validates a given blockchain. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformvalidatedby)"
+          },
+          "response": []
+        },
+        {
+          "name": "validates",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.validates\",\n    \"params\": {\n        \"subnetID\":\"{{caminoSubnetId}}\"\n    },\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseURL}}/ext/bc/P",
+              "host": ["{{baseURL}}"],
+              "path": ["ext", "bc", "P"]
+            },
+            "description": "Get the IDs of the blockchains a Subnet validates. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformvalidates)"
+          },
+          "response": []
+        }
+      ],
+      "description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Avalanche’s validator set and handles blockchain creation. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain)"
+    }
+  ]
 }

--- a/Camino.postman_collection.json
+++ b/Camino.postman_collection.json
@@ -1019,7 +1019,7 @@
           "response": []
         }
       ],
-      "description": "The X-Chain, Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.avax.network/v1.0/en/api/avm)"
+      "description": "The X-Chain, Camino’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/evm)"
     },
     {
       "name": "EVM",
@@ -1135,7 +1135,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting an account’s non-AVAX balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-non-avax-balance)"
+            "description": "Getting an account’s non-AVAX balance. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/evm/#getting-an-accounts-non-avax-balance)"
           },
           "response": []
         },
@@ -1296,7 +1296,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting a block by number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-block-by-number)"
+            "description": "Getting a block by number. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/evm/#getting-a-block-by-number)"
           },
           "response": []
         },
@@ -1319,7 +1319,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting a transaction by hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-by-hash)"
+            "description": "Getting a transaction by hash. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/evm/#getting-a-transaction-by-hash)"
           },
           "response": []
         },
@@ -1342,7 +1342,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting a transaction receipt. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-transaction-receipt)"
+            "description": "Getting a transaction receipt. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/evm/#getting-a-transaction-receipt)"
           },
           "response": []
         },
@@ -1365,30 +1365,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
-          },
-          "response": []
-        },
-        {
-          "name": "exportAVAX",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"method\" :\"avax.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 999000000,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\" \n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{baseURL}}/ext/bc/C/avax",
-              "host": ["{{baseURL}}"],
-              "path": ["ext", "bc", "C", "avax"]
-            },
-            "description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+            "description": "Send asset from the C-Chain to an account on the X-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#avaxexportavax)"
           },
           "response": []
         },
@@ -1411,7 +1388,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportkey)\n\n"
+            "description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#avaxexportkey)\n\n"
           },
           "response": []
         },
@@ -1434,7 +1411,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+            "description": "Returns the specified transaction [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/x-chain/#avaxgetbalance)"
           },
           "response": []
         },
@@ -1457,7 +1434,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgettxstatus)"
+            "description": "Get the status of a transaction sent to the network. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#avaxgettxstatus)"
           },
           "response": []
         },
@@ -1480,7 +1457,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+            "description": "Get the UTXOs that reference a given address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#avaxgetutxos)"
           },
           "response": []
         },
@@ -1503,30 +1480,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
-          },
-          "response": []
-        },
-        {
-          "name": "importAVAX",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{caminoUserName}}\",\n        \"password\":\"{{caminoPassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{baseURL}}/ext/bc/C/avax",
-              "host": ["{{baseURL}}"],
-              "path": ["ext", "bc", "C", "avax"]
-            },
-            "description": "Import AVAX from the X-Chain to an account on the C-Chain.\nBefore calling this method, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/evm/#evmimportavax)"
+            "description": "Finalize the transfer of a non-CAM or CAM from the X-Chain to the C-Chain. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#avaximport)"
           },
           "response": []
         },
@@ -1549,7 +1503,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "avax"]
             },
-            "description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
+            "description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#avaximportkey)"
           },
           "response": []
         },
@@ -1595,7 +1549,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting the network ID. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-network-id)"
+            "description": "Getting the network ID. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#getting-the-network-id)"
           },
           "response": []
         },
@@ -1664,7 +1618,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Listing accounts loaded in EVM node. [More info](https://docs.avax.network/v1.0/en/api/evm/#listing-accounts-loaded-in-evm-node)"
+            "description": "Listing accounts loaded in EVM node. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#listing-accounts-loaded-in-evm-node)"
           },
           "response": []
         },
@@ -1687,7 +1641,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.avax.network/v1.0/en/api/evm/#unlocking-an-account)"
+            "description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#unlocking-an-account)"
           },
           "response": []
         },
@@ -1710,7 +1664,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-count-of-pending-transactions)"
+            "description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#getting-count-of-pending-transactions)"
           },
           "response": []
         },
@@ -1733,7 +1687,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Getting the current client version. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-current-client-version)"
+            "description": "Getting the current client version. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#getting-the-current-client-version)"
           },
           "response": []
         },
@@ -1756,7 +1710,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "C", "rpc"]
             },
-            "description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
+            "description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/c-chain/#calculate-a-cryptographic-hash)"
           },
           "response": []
         }
@@ -2379,7 +2333,7 @@
           ]
         }
       ],
-      "description": "This API can be used to query data from AvalancheGo's database. The Index API is only available when node is run with --index-enabled option."
+      "description": "This API can be used to query data from Camino's database. The Index API is only available when node is run with --index-enabled option."
     },
     {
       "name": "Info",
@@ -3227,7 +3181,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "P"]
             },
-            "description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
+            "description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain#platformgettotalstake)"
           },
           "response": []
         },
@@ -3480,7 +3434,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "P"]
             },
-            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+            "description": "Returns the specified transaction [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgetbalance)"
           },
           "response": []
         },
@@ -3503,7 +3457,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "P"]
             },
-            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+            "description": "Returns the specified transaction [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgettimestamp)"
           },
           "response": []
         },
@@ -3526,7 +3480,7 @@
               "host": ["{{baseURL}}"],
               "path": ["ext", "bc", "P"]
             },
-            "description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+            "description": "Returns the specified transaction [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain/#platformgettxstatus)"
           },
           "response": []
         },
@@ -3784,7 +3738,7 @@
           "response": []
         }
       ],
-      "description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Avalanche’s validator set and handles blockchain creation. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain)"
+      "description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Camino’s validator set and handles blockchain creation. [More info](https://docs.camino.foundation/developer/apis/camino-node-apis/p-chain)"
     }
   ]
 }

--- a/Camino.postman_collection.json
+++ b/Camino.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "17cfc183-e372-47e0-9cea-0af1bc885725",
+		"_postman_id": "89c2c02e-22ee-4188-a8bf-659ff88a358a",
 		"name": "Camino",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "18563164"
+		"_exporter_id": "16493174"
 	},
 	"item": [
 		{
@@ -17,6 +17,34 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.alias\",\n    \"params\": {\n        \"alias\":\"myAlias\",\n        \"endpoint\":\"bc/X\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/admin",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"admin"
+							]
+						},
+						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/build/apis/admin-api#admin-alias)"
+					},
+					"response": []
+				},
+				{
+					"name": "getNodeSigner",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getNodeSigner\",\n    \"params\": {\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3550,6 +3578,118 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDaoProposal\",\n    \"params\": {\n        \"proposalType\":1,\n        \"startTime\":0,\n        \"endTime\":600,\n        \"lockAmount\":1000000000,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"from\": [\"{{pchainAddress}}\"]\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setAddressState",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"platform.setAddressState\",\n  \"params\" :{\n      \"from\":[\"{{kopernikusPchainAddress}}\"],\n      \"username\":\"{{avalancheUsername}}\",\n      \"password\":\"{{avalanchePassword}}\",\n      \"address\":\"{{kopernikusPchainAddress}}\",\n      \"state\": 34,\n      \"remove\": false\n  }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "registerNode",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.registerNode\",\n    \"params\": {\n        \"oldNodeID\": \"{{avalancheNodeId}}\",\n        \"newNodeID\": \"{{avalancheNodeId}}\",\n        \"consortiumMemberAddress\": \"{{kopernikusPchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "spend",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.spend\",\n    \"params\": {\n        \"lockMode\": 2,\n        \"amountToLock\": 10,\n        \"amountToBurn\": 1,\n        \"from\": [\"{{kopernikusPchainAddress}}\"],\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getConfiguration",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getConfiguration\",\n    \"params\":{\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/local.postman_environment.json
+++ b/local.postman_environment.json
@@ -1,122 +1,122 @@
 {
-	"id": "199372cf-ae5c-4a4f-a96a-675dfc7f4576",
-	"name": "local",
-	"values": [
-		{
-			"key": "protocol",
-			"value": "http",
-			"enabled": true
-		},
-		{
-			"key": "host",
-			"value": "localhost",
-			"enabled": true
-		},
-		{
-			"key": "port",
-			"value": "9650",
-			"enabled": true
-		},
-		{
-			"key": "avalancheUsername",
-			"value": "USERNAME",
-			"enabled": true
-		},
-		{
-			"key": "avalanchePassword",
-			"value": "PASSWORD",
-			"enabled": true
-		},
-		{
-			"key": "avalanceBlockchainId",
-			"value": "2VvmkRw4yrz8tPrVnCCbvEK1JxNyujpqhmU6SGonxMpkWBx9UD",
-			"enabled": true
-		},
-		{
-			"key": "avalancheNodeId",
-			"value": "NodeID-DbTaQeTKet4gmzJ1iVkQmj4tRt94Fyduf",
-			"enabled": true
-		},
-		{
-			"key": "avalancheSubnetId",
-			"value": "2bGsYJorY6X7RhjPBFs3kYjiNEHo4zGrD2eeyZbb43T2KKi7fM",
-			"enabled": true
-		},
-		{
-			"key": "avaxAssetId",
-			"value": "CAM",
-			"enabled": true
-		},
-		{
-			"key": "xchainAddress",
-			"value": "X-columbus17pysyr6av4n2gf6teqv3kjd5ewdkmncwrhq6qk",
-			"enabled": true
-		},
-		{
-			"key": "pchainAddress",
-			"value": "P-columbus17pysyr6av4n2gf6teqv3kjd5ewdkmncwrhq6qk",
-			"enabled": true
-		},
-		{
-			"key": "cchainAddress",
-			"value": "0xffcd1238db10793758c29733e91e784d9bb54651",
-			"enabled": true
-		},
-		{
-			"key": "cchainPassphrase",
-			"value": "YOUR_PASSWORD",
-			"enabled": true
-		},
-		{
-			"key": "privkey",
-			"value": "PrivateKey-cE23vJcGNdTR7TNqpoayX8JF2k7CaCbUNdxRNc49Zvcm3MLMo",
-			"enabled": true
-		},
-		{
-			"key": "authPassword",
-			"value": "PASSWORD",
-			"enabled": true
-		},
-		{
-			"key": "cchainbech32address",
-			"value": "C-columbus17pysyr6av4n2gf6teqv3kjd5ewdkmncwrhq6qk",
-			"enabled": true
-		},
-		{
-			"key": "customSubnetID",
-			"value": "j87H8JFHc3wWQ8FQ3P8gGyu9UHdPcz3BcqNTvJKUG6AJ6DDpF",
-			"enabled": true
-		},
-		{
-			"key": "memo",
-			"value": "2ug3siZMAGvW7bvgsaV4NZtvCSF8iuCnRGavujqT32qJ3AW",
-			"enabled": true
-		},
-		{
-			"key": "baseURL",
-			"value": "http://127.0.0.1:9650",
-			"enabled": true
-		},
-		{
-			"key": "",
-			"value": "",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "lastAcceptedTxID",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
-			"key": "lastAcceptedPTxID",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		}
-	],
-	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-06-28T10:03:26.275Z",
-	"_postman_exported_using": "Postman/9.21.5"
+  "id": "199372cf-ae5c-4a4f-a96a-675dfc7f4576",
+  "name": "local",
+  "values": [
+    {
+      "key": "protocol",
+      "value": "http",
+      "enabled": true
+    },
+    {
+      "key": "host",
+      "value": "localhost",
+      "enabled": true
+    },
+    {
+      "key": "port",
+      "value": "9650",
+      "enabled": true
+    },
+    {
+      "key": "caminoUserName",
+      "value": "USERNAME",
+      "enabled": true
+    },
+    {
+      "key": "caminoPassword",
+      "value": "PASSWORD",
+      "enabled": true
+    },
+    {
+      "key": "caminoBlockchainId",
+      "value": "2VvmkRw4yrz8tPrVnCCbvEK1JxNyujpqhmU6SGonxMpkWBx9UD",
+      "enabled": true
+    },
+    {
+      "key": "caminoNodeId",
+      "value": "NodeID-DbTaQeTKet4gmzJ1iVkQmj4tRt94Fyduf",
+      "enabled": true
+    },
+    {
+      "key": "caminoSubnetId",
+      "value": "2bGsYJorY6X7RhjPBFs3kYjiNEHo4zGrD2eeyZbb43T2KKi7fM",
+      "enabled": true
+    },
+    {
+      "key": "camAssetId",
+      "value": "CAM",
+      "enabled": true
+    },
+    {
+      "key": "xchainAddress",
+      "value": "X-columbus17pysyr6av4n2gf6teqv3kjd5ewdkmncwrhq6qk",
+      "enabled": true
+    },
+    {
+      "key": "pchainAddress",
+      "value": "P-columbus17pysyr6av4n2gf6teqv3kjd5ewdkmncwrhq6qk",
+      "enabled": true
+    },
+    {
+      "key": "cchainAddress",
+      "value": "0xffcd1238db10793758c29733e91e784d9bb54651",
+      "enabled": true
+    },
+    {
+      "key": "cchainPassphrase",
+      "value": "YOUR_PASSWORD",
+      "enabled": true
+    },
+    {
+      "key": "privkey",
+      "value": "PrivateKey-cE23vJcGNdTR7TNqpoayX8JF2k7CaCbUNdxRNc49Zvcm3MLMo",
+      "enabled": true
+    },
+    {
+      "key": "authPassword",
+      "value": "PASSWORD",
+      "enabled": true
+    },
+    {
+      "key": "cchainbech32address",
+      "value": "C-columbus17pysyr6av4n2gf6teqv3kjd5ewdkmncwrhq6qk",
+      "enabled": true
+    },
+    {
+      "key": "customSubnetID",
+      "value": "j87H8JFHc3wWQ8FQ3P8gGyu9UHdPcz3BcqNTvJKUG6AJ6DDpF",
+      "enabled": true
+    },
+    {
+      "key": "memo",
+      "value": "2ug3siZMAGvW7bvgsaV4NZtvCSF8iuCnRGavujqT32qJ3AW",
+      "enabled": true
+    },
+    {
+      "key": "baseURL",
+      "value": "http://127.0.0.1:9650",
+      "enabled": true
+    },
+    {
+      "key": "",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "lastAcceptedTxID",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
+      "key": "lastAcceptedPTxID",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2022-06-28T10:03:26.275Z",
+  "_postman_exported_using": "Postman/9.21.5"
 }


### PR DESCRIPTION
- add platform.getConfiguration that returns platformVM configuration
- add (platform.spend) RPC handler to platformVM service, that handles inputs/outputs generation for burn/lock tokens operation.
- add (platform.registerNode) RPC handler to platformVM service, that handles Map/unmap new/old nodeIDs to consortium members.
- add (platform.setAddressState) RPC handler to platformVM service, that Issues an AddressStateTx transaction which assigns state to an address.
- add (admin.getNodeSigner) RPC handler to Admin service, that handles NodeID generation from node's key implementation.
- add from field to platform.addValidator and platform.addDelegator calls
- cleanup docs URL and avalanche placeholder